### PR TITLE
Allow for os 1.0 gem

### DIFF
--- a/mozjpeg.gemspec
+++ b/mozjpeg.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "minitest", "~> 5.4.2"
 
-  spec.add_dependency "os", "~> 0.9.6"
+  spec.add_dependency "os", ">= 0.9.6", "< 2.0"
 end


### PR DESCRIPTION
This very simple update allows to use os v1.0
the test passes on macos 